### PR TITLE
prevent accidental removal of boost.zip

### DIFF
--- a/pre-install.sh
+++ b/pre-install.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 
-unzip boost.zip
+unzip boost.zip || exit 1 # if unzip is missing, the next command removes boost.zip - new cloning is necessary to restore it
 rm boost.zip


### PR DESCRIPTION
if unzip is missing (e.g. on default install of Ubuntu in WSL of Windows 10), the next command removes boost.zip - project removal and new cloning is necessary to restore it